### PR TITLE
Fix typo `= engine =`

### DIFF
--- a/0_Introduction.ipynb
+++ b/0_Introduction.ipynb
@@ -488,7 +488,7 @@
    "source": [
     "from sqlalchemy import create_engine\n",
     "\n",
-    "sql_connection = engine = create_engine('sqlite:///data/greek.db')\n",
+    "sql_connection = create_engine('sqlite:///data/greek.db')\n",
     "sql_df = pd.read_sql('select * from duke', sql_connection)\n",
     "sql_df.head()"
    ]


### PR DESCRIPTION
Remove  `= engine` in line `sql_connection = engine = create_engine('sqlite:///data/greek.db')`